### PR TITLE
Changed class name from column to columnized-column and update of calculation.

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -301,7 +301,7 @@
 					/* create column */
 					var className = (i == 0) ? "first columnized-column" : "columnized-column";
 					var className = (i == numCols - 1) ? ("last " + className) : className;
-          var col_width = options.columns ? (Math.floor(100 / numCols) - 1) + "%" : options.width + "px";
+          var col_width = options.columns ? Math.floor(100 / numCols) + "%" : options.width + "px";
 					$inBox.append($("<div class='" + className + "' style='width:" + col_width + "; float: " + options.columnFloat + ";'></div>")); //"
 				}
 				


### PR DESCRIPTION
1. The class name "column" is too common and is often used in core. Changed it to "columnized-column" so it won't interfer.
2. When I used the "width" option it didn't use it, so I fixed calculation so it uses it when columns-option is not passed in. 
