### PR TITLE
Update src/jquery.columnizer.js

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -251,6 +251,8 @@
 		}
 		
 		function columnizeIt() {
+			//reset adjustment var
+			adjustment = 0;
 			if(lastWidth == $inBox.width()) return;
 			lastWidth = $inBox.width();
 			


### PR DESCRIPTION
on resize the column height is recalculated and by that it looses the adjustment added to it.
but the variable adjustment ist not reset to 0 so it will not execute the if clause in line 379 another time once adjustment has a value greater than 100.
