### PR TITLE
Bug fix for one column / singleColumnizeIt

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -342,7 +342,7 @@
 				overflow.innerHTML = html;
 
 			}else{
-				$col.append($destroyable);
+				$col.append($destroyable.contents());
 			}
 			$inBox.data("columnizing", false);
 			


### PR DESCRIPTION
Fixed a bug that caused an extra div wrapper around columnized content when it only used one column. By appending the contents of the $destroyable instead of $destroyable, this issue is solved.
