### PR TITLE
Readme updated to include wiki content

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,5 @@ Make sure that your content "has display". If the content you're columnizing has
 ### Minimize
 To compress into a zip file, run compress.sh
 
-
-### Questions?
-Check out the [Wiki](https://github.com/adamwulf/Columnizer-jQuery-Plugin/wiki)
-
-
 ### Bug report?
 Check the issues on the [GitHub page](https://github.com/adamwulf/Columnizer-jQuery-Plugin/issues)


### PR DESCRIPTION
When considering plugins (or any 3rd-party code, really), I personally find it very helpful to see an overview of the options I'll have at my disposal when considering a particular plugin. Having the documentation on a wiki page is good (and makes sense), but not everyone may think to look there.

In the interest of making things as easy as possible for our fellow developers, I simply moved the content from both wiki pages (which was exactly what I was looking for initially) to the readme so it's easily findable for first-time visitors.
