### PR TITLE
$.browser.msie

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -95,15 +95,11 @@
 		
 		if(!options.buildOnce){
 			$(window).resize(function() {
-				if(!options.buildOnce && $.browser.msie){
+				if(!options.buildOnce){
 					if($inBox.data("timeout")){
 						clearTimeout($inBox.data("timeout"));
 					}
 					$inBox.data("timeout", setTimeout(columnizeIt, 200));
-				}else if(!options.buildOnce){
-					columnizeIt();
-				}else{
-					// don't rebuild
 				}
 			});
 		}


### PR DESCRIPTION
$.browser.msie is deprecated since jquery 1.9
In my opinion the msie workaround is a good solution for all 
browsers to prevent unnecessary columnizeIt function calls so 
I edited it to go this way as default.
