### PR TITLE
JSLint improvement

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -427,7 +427,7 @@
 			// options that would cause an infinite loop, then this'll definitely stop it.
 			for(var loopCount=0;loopCount<maxLoops && maxLoops < 20;loopCount++){
 				$inBox.empty();
-				var $destroyable;
+				var $destroyable, className, $col, $lastKid;
 				try{
 					$destroyable = $cache.clone(true);
 				}catch(e){
@@ -438,7 +438,7 @@
 				// create the columns
 				for (var i = 0; i < numCols; i++) {
 					/* create column */
-					var className = (i === 0) ? prefixTheClassName("first") : "";
+					className = (i === 0) ? prefixTheClassName("first") : "";
 					className += " " + prefixTheClassName("column");
 					className = (i == numCols - 1) ? (prefixTheClassName("last") + " " + className) : className;
 					$inBox.append($("<div class='" + className + "' style='width:" + (Math.floor(100 / numCols))+ "%; float: " + options.columnFloat + ";'></div>")); //"
@@ -451,7 +451,7 @@
 						// we ran out of columns, make another
 						$inBox.append($("<div class='" + className + "' style='width:" + (Math.floor(100 / numCols))+ "%; float: " + options.columnFloat + ";'></div>")); //"
 					}
-					var $col = $inBox.children().eq(i);
+					$col = $inBox.children().eq(i);
 					if(scrollHorizontally){
 						$col.width(optionWidth + "px");
 					}
@@ -460,7 +460,7 @@
 					split($col, $destroyable, $col, targetHeight);
 
 					while($col.contents(":last").length && checkDontEndColumn($col.contents(":last").get(0))){
-						var $lastKid = $col.contents(":last");
+						$lastKid = $col.contents(":last");
 						$lastKid.remove();
 						$destroyable.prepend($lastKid);
 					}


### PR DESCRIPTION
Cleaned up the code using JSLint as a guide for best practice. Doesn't change the functionality, just reduces the chance of unexpected errors and improves maintenance.

Changes include:
1. ensure vars are declared out of loop and are not out of scope define radix for parseint
2. using !== to compare to null and removed repeated var declaration removed repeated var 
3. declarations added missing semicolons
4. updated another comparison to 0 to ===
5. using === to compare to 0
6. removed all trailing whitespace and mixture of space and tabs
