### PR TITLE
Simple gaps between columns

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -10,6 +10,8 @@
 	var defaults = {
 		// default width of columns
 		width: 400,
+		// optional gap (in px) between columns
+		gap: 0,
 		// optional # of columns instead of width
 		columns : false,
 		// true to build columns once regardless of window resize
@@ -48,6 +50,8 @@
 			options.width = defaults.width;
 		}
 	}
+
+	options.width += options.gap;
 
     return this.each(function() {
 		var $inBox = options.target ? $(options.target) : $(this);
@@ -164,7 +168,7 @@
 			if($item[0].nodeType == 3){
 				// it's a text node, split it up
 				var oText = $item[0].nodeValue;
-				var counter2 = options.width / 18;
+				var counter2 = (options.width - options.gap) / 18;
 				if(options.accuracy)
 				counter2 = options.accuracy;
 				var columnText;
@@ -398,7 +402,14 @@
 			$inBox.data("columnizing", true);
 
 			$inBox.empty();
-			$inBox.append($("<div style='width:" + (Math.floor(100 / numCols))+ "%; float: " + options.columnFloat + ";'></div>")); //"
+			$inBox.append($( "<div style='"
+				       + "width: " + (options.width - options.gap) + "px;"
+				       + "float: " + options.columnFloat + ";"
+				       + "margin-left:" + options.gap / 2 + "px;"
+				       + "margin-right:" + options.gap / 2 + "px;"
+				       + "'></div>"
+				       )
+				    ); //"
 			$col = $inBox.children(":last");
 			$col.append($cache.clone());
 			maxHeight = $col.height();
@@ -441,7 +452,14 @@
 					className = (i === 0) ? prefixTheClassName("first") : "";
 					className += " " + prefixTheClassName("column");
 					className = (i == numCols - 1) ? (prefixTheClassName("last") + " " + className) : className;
-					$inBox.append($("<div class='" + className + "' style='width:" + (Math.floor(100 / numCols))+ "%; float: " + options.columnFloat + ";'></div>")); //"
+					$inBox.append($( "<div style='"
+						       + "width: " + (options.width - options.gap) + "px;"
+						       + "float: " + options.columnFloat + ";"
+						       + "margin-left:" + options.gap / 2 + "px;"
+						       + "margin-right:" + options.gap / 2 + "px;"
+						       + "'></div>"
+						       )
+						     ); //"
 				}
 
 				// fill all but the last column (unless overflowing)
@@ -449,7 +467,14 @@
 				while(i < numCols - (options.overflow ? 0 : 1) || scrollHorizontally && $destroyable.contents().length){
 					if($inBox.children().length <= i){
 						// we ran out of columns, make another
-						$inBox.append($("<div class='" + className + "' style='width:" + (Math.floor(100 / numCols))+ "%; float: " + options.columnFloat + ";'></div>")); //"
+						$inBox.append($( "<div style='"
+							       + "width: " + (options.width - options.gap) + "px;"
+							       + "float: " + options.columnFloat + ";"
+							       + "margin-left:" + options.gap / 2 + "px;"
+							       + "margin-right:" + options.gap / 2 + "px;"
+							       + "'></div>"
+							       )
+							     ); //"
 					}
 					$col = $inBox.children().eq(i);
 					if(scrollHorizontally){


### PR DESCRIPTION
This is a simple implementation for adding gaps to the left and the right of columns.

Setting gap to a non-zero value, e.g. 40 will add 20px to the left and
right of each column as additional gap. This is done by setting the
margin-{left,right} css style. Columns themselves are resized to width - gap.
