### PR TITLE
Fix not splitting elements and unnecessary overflowing in close fit case

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -250,7 +250,7 @@
 						// we can't split an img in half, so just add it
 						// to the column and remove it from the pullOutHere section
 						$cloneMe.remove();
-					}else if(!$cloneMe.hasClass(prefixTheClassName("dontsplit")) && $parentColumn.height() < targetHeight + 20){
+					}else if($cloneMe.hasClass(prefixTheClassName("dontsplit")) && $parentColumn.height() < targetHeight + 20){
 						//
 						// pretty close fit, and we're not allowed to split it, so just
 						// add it to the column, remove from pullOutHere, and be done


### PR DESCRIPTION
The wrong condition causes that in closefit case regular elements (WITHOUT dontsplit class) are being put entirely into the current column without even trying to split them. Because of that, it often overflows, even if there's no reason for that, because we can actually split it very accurately.
