### PR TITLE
enable use of fuzzypos class

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -192,7 +192,7 @@
 				counter2 = options.accuracy;
 				var columnText;
 				var latestTextNode = null;
-				while($parentColumn.height() < targetHeight && oText.length){
+                while($parentColumn.height() <= (targetHeight + 20) && oText.length){
 					//
 					// it's been brought up that this won't work for chinese
 					// or other languages that don't have the same use of whitespace


### PR DESCRIPTION
.fuzzypos marks an element as having a fuzzy position - the element can
be pushed around if it doesn't fit where it was originally placed
