### PR TITLE
added maxColWidth parameter

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -19,6 +19,9 @@
 		width: 400,
 		// optional # of columns instead of width
 		columns : false,
+		// Optional, The width of a column can grow to maxColWidth (padding included!).
+		// Columns will be added if the the container is wider
+		maxColWidth:false,
 		// true to build columns once regardless of window resize
 		// false to rebuild when content box changes bounds
 		buildOnce : false,
@@ -432,6 +435,13 @@
 			if(manualBreaks){
 				numCols = $cache.find(prefixTheClassName("columnbreak", true)).length + 1;
 				optionWidth = false;
+			}
+			
+			if ( options.maxColWidth ){
+				numCols=1;
+				while ( ( numCols  * options.maxColWidth ) < $inBox.width() ) {
+				++numCols;
+				}
 			}
 
 //			if ($inBox.data("columnized") && numCols == $inBox.children().length) {


### PR DESCRIPTION
Hi,

I forked your (very nice) plugin and added a new parameter "maxColWidth", basically to use it more flexible in fluid / responsive designs.

Culumns "grow" to maxColWidth. When the parent container gets larger new columns are added.

eg. 
maxColWidth =500 & container=400 => one colum of 400
maxColWidth =500 & container=600 => two colums of 300

Regards

Bart
