### PR TITLE
Remove trailing comma from object literal.

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -50,7 +50,7 @@
 		// default to empty string for backwards compatibility
 		cssClassPrefix : "",
 		elipsisText:'...',
-		debug:0,	
+		debug:0
 	};
 	options = $.extend(defaults, options);
 


### PR DESCRIPTION
The trailing comma makes old (really old) versions of IE unhappy.
