### PR TITLE
Bump version number.

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -1,4 +1,4 @@
-// version 1.6.0
+// version 1.6.2
 // http://welcome.totheinter.net/columnizer-jquery-plugin/
 // created by: Adam Wulf @adamwulf, adam.wulf@gmail.com
 


### PR DESCRIPTION
This simply matches the .js file number with the release number to avoid confusion. Also, while version 1.6.2 is the latest version since last November the only version available on Bower is 1.6.1. I'm not sure which version addresses this because of the version mismatch but:

When I download your plugin from Bower I get a .bower.json file that lacks a "main" key which means when trying to use Browserify it can't find the actual JS file. The solution in my eyes is to make a new release from 1.6.1 to 1.6.2. Perhaps this will carry over the change you've already made and update it on Bower.