### PR TITLE
Added an ability to launch recolumning from external scope

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -141,7 +141,7 @@
 		columnizeIt();
 
 		if(!options.buildOnce){
-			$(window).resize(function() {
+			$(window).on('resize.columnizer', function() {
 				if(!options.buildOnce){
 					if($inBox.data("timeout")){
 						clearTimeout($inBox.data("timeout"));

--- a/src/jquery.columnizer.min.js
+++ b/src/jquery.columnizer.min.js
@@ -7,7 +7,7 @@ if(!options.setWidth){if(options.precise){options.setWidth=function(numCols){ret
 function appendSafe($target,$elem){try{$target.append($elem);}catch(e){$target[0].appendChild($elem[0]);}}
 return this.each(function(){var $inBox=options.target?$(options.target):$(this);var maxHeight=$(this).height();var $cache=$('<div></div>');var lastWidth=0;var columnizing=false;var manualBreaks=options.manualBreaks;var cssClassPrefix=defaults.cssClassPrefix;if(typeof(options.cssClassPrefix)=="string"){cssClassPrefix=options.cssClassPrefix;}
 var adjustment=0;appendSafe($cache,$(this).contents().clone(true));if(!options.ignoreImageLoading&&!options.target){if(!$inBox.data("imageLoaded")){$inBox.data("imageLoaded",true);if($(this).find("img").length>0){var func=function($inBox,$cache){return function(){if(!$inBox.data("firstImageLoaded")){$inBox.data("firstImageLoaded","true");appendSafe($inBox.empty(),$cache.children().clone(true));$inBox.columnize(options);}};}($(this),$cache);$(this).find("img").one("load",func);$(this).find("img").one("abort",func);return;}}}
-$inBox.empty();columnizeIt();if(!options.buildOnce){$(window).resize(function(){if(!options.buildOnce){if($inBox.data("timeout")){clearTimeout($inBox.data("timeout"));}
+$inBox.empty();columnizeIt();if(!options.buildOnce){$(window).on('resize.columnizer',function(){if(!options.buildOnce){if($inBox.data("timeout")){clearTimeout($inBox.data("timeout"));}
 $inBox.data("timeout",setTimeout(columnizeIt,200));}});}
 function prefixTheClassName(className,withDot){var dot=withDot?".":"";if(cssClassPrefix.length){return dot+cssClassPrefix+"-"+className;}
 return dot+className;}


### PR DESCRIPTION
Sometimes there is a need to rebuild columns when window is not resized. Before it could be done by `$(window).resize()`, but it awakes all other plugins listening to window resize event.

Now it is possible to trigger window resize event that is handled only by Columnizer. So this `$(window).trigger('resize.columnizer')` makes columns be recalculated, meanwhile standard window resize event still handled properly.