### PR TITLE
Correctly test for whitespace-only nodeValues

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -348,9 +348,9 @@
                             var onlyNode = $clone.get(0).childNodes[0];
                             if(onlyNode.nodeType == 3){
                                 // text node
-                                var whitespace = /\s/;
+                                var nonwhitespace = /\S/;
                                 var str = onlyNode.nodeValue;
-                                if(whitespace.test(str)){
+                                if(!nonwhitespace.test(str)){
                                     // yep, only a whitespace textnode
                                     $clone.remove();
 									$cloneMe.removeClass(prefixTheClassName("split"));


### PR DESCRIPTION
As written, a nodeValue of "test test" will return True which appears to be the incorrect behavior. I believe only empty nodeValues and nodes that only have whitespace characters should return True.

This fix looks for any non-whitespace characters in nodeValue and only returns True if none are found.