### PR TITLE
Fix for jQuery deprecation of event shorthand: resize

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -212,7 +212,7 @@
 		columnizeIt();
 
 		if(!options.buildOnce){
-			$(window).resize(function() {
+			$(window).on('resize', function() {
 				if(!options.buildOnce){
 					if($inBox.data("timeout")){
 						clearTimeout($inBox.data("timeout"));

--- a/src/jquery.columnizer.min.js
+++ b/src/jquery.columnizer.min.js
@@ -1,5 +1,11 @@
 
-(function($){var DATA_ORIGINAL_DOM_KEY='columnizer-original-dom';$.fn.columnize=function(options){this.each(function(){var $el=$(this);$el.data(DATA_ORIGINAL_DOM_KEY,$el.clone(true,true));});this.cols=[];this.offset=0;this.before=[];this.lastOther=0;this.prevMax=0;this.debug=0;this.setColumnStart=null;this.elipsisText='';var defaults={width:400,columns:false,buildOnce:false,overflow:false,doneFunc:function(){},target:false,ignoreImageLoading:true,columnFloat:"left",lastNeverTallest:false,accuracy:false,precise:false,manualBreaks:false,disableSingle:false,cssClassPrefix:"",elipsisText:'...',debug:0};options=$.extend(defaults,options);if(typeof(options.width)=="string"){options.width=parseInt(options.width,10);if(isNaN(options.width)){options.width=defaults.width;}}
+(function($){var DATA_ORIGINAL_DOM_KEY='columnizer-original-dom';$.fn.columnize=function(options){this.each(function(){var $el=$(this);$el.data(DATA_ORIGINAL_DOM_KEY,$el.clone(true,true));});this.cols=[];this.offset=0;this.before=[];this.lastOther=0;this.prevMax=0;this.debug=0;this.setColumnStart=null;this.elipsisText='';var defaults={width:400,columns:false,buildOnce:false,overflow:false,doneFunc:function(){},target:false,ignoreImageLoading:true,columnFloat:"left",lastNeverTallest:false,accuracy:false,precise:false,manualBreaks:false,disableSingle:false,cssClassPrefix:"",elipsisText:'...',debug:0};options=$.extend(defaults,options);var tables=new Array();$('table').each(function(){if(!$(this).hasClass('tableSaved')){$(this).addClass('tableSaved')
+$(this).addClass('tableID-'+tables.length)
+tables.push({tableID:'tableID-'+tables.length,thead:$(this).find('thead:first').clone(),tfoot:$(this).find('tfoot:first').clone()});}});function fixTables($pullOutHere){for(i=0;i<tables.length;i++){if($pullOutHere.is("table")){if($pullOutHere.children('tfoot').length==0&&$pullOutHere.hasClass(tables[i].tableID)){$(tables[i].tfoot).clone().prependTo($pullOutHere);}
+if($pullOutHere.children('thead').length==0&&$pullOutHere.hasClass(tables[i].tableID)){$(tables[i].thead).clone().prependTo($pullOutHere);}}
+$pullOutHere.find('table .'+tables[i].tableID).each(function(){if($(this).children('tfoot').length==0){$(tables[i].tfoot).clone().prependTo(this);}
+if($(this).children('thead').length==0){$(tables[i].thead).clone().prependTo(this);}});}}
+if(typeof(options.width)=="string"){options.width=parseInt(options.width,10);if(isNaN(options.width)){options.width=defaults.width;}}
 if(typeof options.setColumnStart=='function'){this.setColumnStart=options.setColumnStart;}
 if(typeof options.elipsisText=='string'){this.elipsisText=options.elipsisText;}
 if(options.debug){this.debug=options.debug;}
@@ -7,7 +13,7 @@ if(!options.setWidth){if(options.precise){options.setWidth=function(numCols){ret
 function appendSafe($target,$elem){try{$target.append($elem);}catch(e){$target[0].appendChild($elem[0]);}}
 return this.each(function(){var $inBox=options.target?$(options.target):$(this);var maxHeight=$(this).height();var $cache=$('<div></div>');var lastWidth=0;var columnizing=false;var manualBreaks=options.manualBreaks;var cssClassPrefix=defaults.cssClassPrefix;if(typeof(options.cssClassPrefix)=="string"){cssClassPrefix=options.cssClassPrefix;}
 var adjustment=0;appendSafe($cache,$(this).contents().clone(true));if(!options.ignoreImageLoading&&!options.target){if(!$inBox.data("imageLoaded")){$inBox.data("imageLoaded",true);if($(this).find("img").length>0){var func=function($inBox,$cache){return function(){if(!$inBox.data("firstImageLoaded")){$inBox.data("firstImageLoaded","true");appendSafe($inBox.empty(),$cache.children().clone(true));$inBox.columnize(options);}};}($(this),$cache);$(this).find("img").one("load",func);$(this).find("img").one("abort",func);return;}}}
-$inBox.empty();columnizeIt();if(!options.buildOnce){$(window).resize(function(){if(!options.buildOnce){if($inBox.data("timeout")){clearTimeout($inBox.data("timeout"));}
+$inBox.empty();columnizeIt();if(!options.buildOnce){$(window).on('resize',function(){if(!options.buildOnce){if($inBox.data("timeout")){clearTimeout($inBox.data("timeout"));}
 $inBox.data("timeout",setTimeout(columnizeIt,200));}});}
 function prefixTheClassName(className,withDot){var dot=withDot?".":"";if(cssClassPrefix.length){return dot+cssClassPrefix+"-"+className;}
 return dot+className;}
@@ -21,11 +27,12 @@ if($parentColumn.height()>=targetHeight&&latestTextNode!==null){$putInHere[0].re
 if(oText.length){$item[0].nodeValue=oText;}else{return false;}}
 if($pullOutHere.contents().length){$pullOutHere.prepend($item);}else{appendSafe($pullOutHere,$item);}
 return $item[0].nodeType==3;}
-function split($putInHere,$pullOutHere,$parentColumn,targetHeight){if($putInHere.contents(":last").find(prefixTheClassName("columnbreak",true)).length){return;}
-if($putInHere.contents(":last").hasClass(prefixTheClassName("columnbreak"))){return;}
+function split($putInHere,$pullOutHere,$parentColumn,targetHeight){if($putInHere.contents(":last").find(prefixTheClassName("columnbreak",true)).length){fixTables($pullOutHere);return;}
+if($putInHere.contents(":last").hasClass(prefixTheClassName("columnbreak"))){fixTables($pullOutHere);return;}
 if($pullOutHere.contents().length){var $cloneMe=$pullOutHere.contents(":first");if(typeof $cloneMe.get(0)=='undefined'||$cloneMe.get(0).nodeType!=1)return;var $clone=$cloneMe.clone(true);if($cloneMe.hasClass(prefixTheClassName("columnbreak"))){appendSafe($putInHere,$clone);$cloneMe.remove();}else if(manualBreaks){appendSafe($putInHere,$clone);$cloneMe.remove();}else if($clone.get(0).nodeType==1&&!$clone.hasClass(prefixTheClassName("dontend"))){appendSafe($putInHere,$clone);if($clone.is("img")&&$parentColumn.height()<targetHeight+20){$cloneMe.remove();}else if($cloneMe.hasClass(prefixTheClassName("dontsplit"))&&$parentColumn.height()<targetHeight+20){$cloneMe.remove();}else if($clone.is("img")||$cloneMe.hasClass(prefixTheClassName("dontsplit"))){$clone.remove();}else{$clone.empty();if(!columnize($clone,$cloneMe,$parentColumn,targetHeight)){$cloneMe.addClass(prefixTheClassName("split"));if($cloneMe.get(0).tagName=='OL'){var startWith=$clone.get(0).childElementCount+$clone.get(0).start;$cloneMe.attr('start',startWith+1);}
 if($cloneMe.children().length){split($clone,$cloneMe,$parentColumn,targetHeight);}}else{$cloneMe.addClass(prefixTheClassName("split"));}
-if($clone.get(0).childNodes.length===0){$clone.remove();$cloneMe.removeClass(prefixTheClassName("split"));}else if($clone.get(0).childNodes.length==1){var onlyNode=$clone.get(0).childNodes[0];if(onlyNode.nodeType==3){var nonwhitespace=/\S/;var str=onlyNode.nodeValue;if(!nonwhitespace.test(str)){$clone.remove();$cloneMe.removeClass(prefixTheClassName("split"));}}}}}}}
+if($clone.get(0).childNodes.length===0){$clone.remove();$cloneMe.removeClass(prefixTheClassName("split"));}else if($clone.get(0).childNodes.length==1){var onlyNode=$clone.get(0).childNodes[0];if(onlyNode.nodeType==3){var nonwhitespace=/\S/;var str=onlyNode.nodeValue;if(!nonwhitespace.test(str)){$clone.remove();$cloneMe.removeClass(prefixTheClassName("split"));}}}}}}
+fixTables($pullOutHere);}
 function singleColumnizeIt(){if($inBox.data("columnized")&&$inBox.children().length==1){return;}
 $inBox.data("columnized",true);$inBox.data("columnizing",true);$inBox.empty();$inBox.append($("<div class='"
 +prefixTheClassName("first")+" "
@@ -42,7 +49,7 @@ function checkDontEndColumn(dom){if(dom.nodeType==3){if(/^\s+$/.test(dom.nodeVal
 return false;}
 if(dom.nodeType!=1)return false;if($(dom).hasClass(prefixTheClassName("dontend")))return true;if(dom.childNodes.length===0)return false;return checkDontEndColumn(dom.childNodes[dom.childNodes.length-1]);}
 function columnizeIt(){adjustment=0;if(lastWidth==$inBox.width())return;lastWidth=$inBox.width();var numCols=Math.round($inBox.width()/options.width);var optionWidth=options.width;var optionHeight=options.height;if(options.columns)numCols=options.columns;if(manualBreaks){numCols=$cache.find(prefixTheClassName("columnbreak",true)).length+1;optionWidth=false;}
-if(numCols<=1&&!disableSingle){return singleColumnizeIt();}
+if(numCols<=1&&!options.disableSingle){return singleColumnizeIt();}
 if($inBox.data("columnizing"))return;$inBox.data("columnized",true);$inBox.data("columnizing",true);$inBox.empty();$inBox.append($("<div style='width:"+options.setWidth(numCols)+"%; float: "+options.columnFloat+";'></div>"));$col=$inBox.children(":last");appendSafe($col,$cache.clone());maxHeight=$col.height();$inBox.empty();var targetHeight=maxHeight/numCols;var firstTime=true;var maxLoops=3;var scrollHorizontally=false;if(options.overflow){maxLoops=1;targetHeight=options.overflow.height;}else if(optionHeight&&optionWidth){maxLoops=1;targetHeight=optionHeight;scrollHorizontally=true;}
 for(var loopCount=0;loopCount<maxLoops&&loopCount<20;loopCount++){$inBox.empty();var $destroyable,className,$col,$lastKid;try{$destroyable=$cache.clone(true);}catch(e){$destroyable=$cache.clone();}
 $destroyable.css("visibility","hidden");for(var i=0;i<numCols;i++){className=(i===0)?prefixTheClassName("first"):"";className+=" "+prefixTheClassName("column");className=(i==numCols-1)?(prefixTheClassName("last")+" "+className):className;$inBox.append($("<div class='"+className+"' style='width:"+options.setWidth(numCols)+"%; float: "+options.columnFloat+";'></div>"));}


### PR DESCRIPTION
Fix for jQuery deprecation notice when using with 3.0+

> jquery-migrate-3.1.0.js:99 JQMIGRATE: jQuery.fn.resize() event shorthand is deprecated
jquery-migrate-3.1.0.js:101 console.trace
migrateWarn     @       jquery-migrate-3.1.0.js:101
jQuery.fn.<computed>    @       jquery-migrate-3.1.0.js:528
(anonymous)     @       jquery.columnizer.js:144