### PR TITLE
fix bug in assigning first and last columns classes when it's scrolling horizontally

### DIFF
--- a/src/jquery.columnizer.js
+++ b/src/jquery.columnizer.js
@@ -740,9 +740,9 @@
 						$col = $inBox.children().eq(i);
 						$col.width(optionWidth + "px");
 						if(i === 0){
-							$col.addClass(prefixTheClassName("first"));
+							$col.removeClass(prefixTheClassName("last"));
 						}else if(i==$inBox.children().length-1){
-							$col.addClass(prefixTheClassName("last"));
+							$col.removeClass(prefixTheClassName("first"));
 						}else{
 							$col.removeClass(prefixTheClassName("first"));
 							$col.removeClass(prefixTheClassName("last"));


### PR DESCRIPTION
hi
In function `columnizeIt()` we should remove unnecessary class from first and last columns, because all columns have `first` and `last` classes in default.